### PR TITLE
Fix typo in RefLine_P2L_C2P

### DIFF
--- a/source/model/ReferenceFinder.cpp
+++ b/source/model/ReferenceFinder.cpp
@@ -2431,7 +2431,7 @@ void RefLine_P2L_C2P::MakeAll(rank_t arank)
               if (ReferenceFinder::GetNumLines() >= 
                 ReferenceFinder::sMaxLines) return;
               RefLine_P2L_C2P rlh2(mi->second, lj->second, mk->second, 1);
-              ReferenceFinder::sBasisLines.AddCopyIfValidAndUnique(rlh1);
+              ReferenceFinder::sBasisLines.AddCopyIfValidAndUnique(rlh2);
             };
             mk++;
           };


### PR DESCRIPTION
This PR fixes a typo in `RefLine_P2L_C2P::MakeAll` which results in ReferenceFinder overlooking some solutions. An example can be seen below, where the second and the fifth solution was missing from ReferenceFinder v4.0.1 with the default settings.

![](https://github.com/bugfolder/ReferenceFinder/assets/39870664/f38e5ff6-1bfb-4477-8525-64a9336ce6e2)
