### PR TITLE
Fix formula for generating the key

### DIFF
--- a/source/model/ReferenceFinder.cpp
+++ b/source/model/ReferenceFinder.cpp
@@ -979,8 +979,8 @@ void RefMark::FinishConstructor()
   const double fx = p.x / ReferenceFinder::sPaper.mWidth;  // fx is between 0 and 1
   const double fy = p.y / ReferenceFinder::sPaper.mHeight; // fy is between 0 and 1
 
-  key_t nx = static_cast<key_t> (floor(0.5 + fx * ReferenceFinder::sNumX));
-  key_t ny = static_cast<key_t> (floor(0.5 + fy * ReferenceFinder::sNumY));
+  key_t nx = static_cast<key_t> (floor(0.5 + fx * (ReferenceFinder::sNumX - 1)));
+  key_t ny = static_cast<key_t> (floor(0.5 + fy * (ReferenceFinder::sNumY - 1)));
   mKey = 1 + nx * ReferenceFinder::sNumY + ny;
 }
 
@@ -1332,9 +1332,9 @@ void RefLine::FinishConstructor()
     pow(ReferenceFinder::sPaper.mHeight, 2));
   const double fd = l.d / dmax; // fd is between 0 and 1
   
-  key_t nd = static_cast <key_t> (floor(0.5 + fd * ReferenceFinder::sNumD));
+  key_t nd = static_cast <key_t> (floor(0.5 + fd * (ReferenceFinder::sNumD - 1)));
   if (nd == 0) fa = fmod(2 * fa, 1);  // for d=0, we map alpha and pi+alpha to the same key
-  key_t na = static_cast <key_t> (floor(0.5 + fa * ReferenceFinder::sNumA));
+  key_t na = static_cast <key_t> (floor(0.5 + fa * (ReferenceFinder::sNumA - 1)));
   mKey = 1 + na * ReferenceFinder::sNumD + nd;
 }
 


### PR DESCRIPTION
When I was developing the new scoring system previously mentioned in our email corresponding, I noticed a weird phenomenon in which, for a point on the boundary of the sheet, the best error found can be very different only by mirroring the point to the other side of the sheet. For example, the best error for (4/7, 0) is 0.0000 (with the "good enough" error set to 0.001), but for (4/7, 1) it becomes 0.0003 with very different sequences.

I investigated into this and realized that there is a bug hidden in the formula calculating the key of a reference object. Specifically, it says:

```cpp
key_t ny = static_cast<key_t> (floor(0.5 + fy * ReferenceFinder::sNumY));
```

which means the maximal possible value of `ny` is exactly `ReferenceFinder::sNumY`. And then

```cpp
mKey = 1 + nx * ReferenceFinder::sNumY + ny;
```

implies that it is possible for two marks on the top and bottom edges to have the same key, if their x-coordiante is about the same. That leads to the observation above, as ReferenceFinder will only keep one of them.

This can be fixed by changing the formula into:

```cpp
key_t ny = static_cast<key_t> (floor(0.5 + fy * (ReferenceFinder::sNumY - 1)));
```